### PR TITLE
fix CI for Julia 1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,13 @@
 name = "Richardson"
 uuid = "708f8203-808e-40c0-ba2d-98a6953ed40d"
 authors = ["Steven G. Johnson <stevenj@mit.edu>"]
-version = "1.4.1"
+version = "1.4.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
 julia = "1"
-LinearAlgebra = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
This doesn't seem supported with Julia 1.0, which this package still supports.  See [this discourse discussion](https://discourse.julialang.org/t/how-does-compat-requirement-changes-for-general-registry-affect-package-maintainers/104960/15?u=stevengj)