### PR TITLE
Fix type instability when `h` is a `float`

### DIFF
--- a/src/Richardson.jl
+++ b/src/Richardson.jl
@@ -75,9 +75,15 @@ function extrapolate(f, h_::Number; contract::Number=oftype(float(real(h_)), 0.1
                      atol::Real=0, rtol::Real = atol > zero(atol) ? zero(one(float(real(x0+h_)))) : sqrt(eps(typeof(one(float(real(x0+h_)))))),
                      maxeval::Integer=typemax(Int), breaktol::Real=2)
     if isinf(x0)
-        # use a change of variables x = 1/u
-        return extrapolate(u -> f(inv(u)), inv(h_); rtol=rtol, atol=atol, maxeval=maxeval, contract = abs(contract) > 1 ? inv(contract) : contract, x0=inv(x0), power=power)
+         # use a change of variables x = 1/u
+         contract = abs(contract) > 1 ? inv(contract) : contract
+        _extrapolate(u -> f(inv(u)), inv(h_), contract, inv(x0), power, atol, rtol, maxeval, breaktol)
+    else
+        _extrapolate(f, h_, contract, x0, power, atol, rtol, maxeval, breaktol)
     end
+end
+
+function _extrapolate(f, h_::Number, contract, x0, power, atol, rtol, maxeval, breaktol)
     (rtol ≥ 0 && atol ≥ zero(atol)) || throw(ArgumentError("rtol and atol must be nonnegative"))
     breaktol > 0 || throw(ArgumentError("breaktol must be positive"))
     0 < abs(contract) < 1 || throw(ArgumentError("contract must be in (0,1)"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -127,3 +127,9 @@ end
     @test_throws ArgumentError extrapolate!([(sin(h)/h,h) for h in [1, 0.8, 1.3]])
     @test_throws ArgumentError extrapolate!([(sin(h)/h,h) for h in [1, 0.8, 0.8]])
 end
+
+
+@testset "type stability" begin
+    @inferred extrapolate(x -> sin(x)/x, 1)
+    @inferred extrapolate(x -> sin(x)/x, 1.0)
+end


### PR DESCRIPTION
On commit 41dc041b1f5be5a70efd75d9cd588d2d64b6ce85, the following code errors on my machine:

```julia
@inferred extrapolate(x -> sin(x)/x, 1.0)
```

while this one works

```julia
@inferred extrapolate(x -> sin(x)/x, 1)
```

I poked around a bit, and it appears that type instability comes from the branch with `x0` infinite, but I failed to really understand what was going on (I suspect it had something to do with the recursive call). This **PR fixes the issue** by factoring out the logic of `extrapolate` into an `_extrapolate` function that takes only positional arguments, thus avoiding the recursive call.